### PR TITLE
Articles archive page

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -3856,6 +3856,30 @@
                 "deprecationReason": null
               },
               {
+                "name": "audienceMaxAgeLt",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "audienceMinAgeGt",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "combinedText",
                 "description": null,
                 "type": {

--- a/i18nRoutes.config.js
+++ b/i18nRoutes.config.js
@@ -7,6 +7,10 @@ const i18nRoutes = {
     { source: '/kurssit/:eventId', locale: 'fi' },
     { source: '/kurser/:eventId', locale: 'sv' },
   ],
+  '/articles': [
+    { source: '/artikkelit', locale: 'fi' },
+    { source: '/artiklar', locale: 'sv' },
+  ],
   '/articles/:slug*': [
     { source: '/artikkelit/:slug*', locale: 'fi' },
     { source: '/artiklar/:slug*', locale: 'sv' },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-content-loader": "^6.2.0",
     "react-datepicker": "^4.8.0",
     "react-dom": "18.1.0",
-    "react-helsinki-headless-cms": "1.0.0-alpha2-canary-0dc40ae",
+    "react-helsinki-headless-cms": "1.0.0-alpha2-canary-bd861cc",
     "react-scroll": "^1.8.7",
     "react-toastify": "^9.0.3",
     "sanitize-html": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-content-loader": "^6.2.0",
     "react-datepicker": "^4.8.0",
     "react-dom": "18.1.0",
-    "react-helsinki-headless-cms": "1.0.0-alpha2-canary-27b5f0d",
+    "react-helsinki-headless-cms": "1.0.0-alpha2-canary-0dc40ae",
     "react-scroll": "^1.8.7",
     "react-toastify": "^9.0.3",
     "sanitize-html": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-content-loader": "^6.2.0",
     "react-datepicker": "^4.8.0",
     "react-dom": "18.1.0",
-    "react-helsinki-headless-cms": "1.0.0-alpha2-canary-d7281fe",
+    "react-helsinki-headless-cms": "1.0.0-alpha2-canary-27b5f0d",
     "react-scroll": "^1.8.7",
     "react-toastify": "^9.0.3",
     "sanitize-html": "^2.7.0",

--- a/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
+++ b/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
@@ -16,7 +16,7 @@ import {
   CardProps,
   isPageType,
   isArticleType,
-  getArticlePageCardProps,
+  getArticlePageCardProps as getArticlePageCardPropsBase,
   ModuleItemTypeEnum,
 } from 'react-helsinki-headless-cms';
 
@@ -83,13 +83,13 @@ export const getEventPlaceholderImage = (id: string): string => {
   return EVENT_PLACEHOLDER_IMAGES[index];
 };
 
-export function _getArticlePageCardProps(
+export function getArticlePageCardProps(
   item: ArticleType,
   getRoutedInternalHref: RCHCConfig['utils']['getRoutedInternalHref'],
   defaultImageUrl: string
 ): CardProps {
   return {
-    ...getArticlePageCardProps(item, defaultImageUrl),
+    ...getArticlePageCardPropsBase(item, defaultImageUrl),
     subTitle: item?.date
       ? format(new Date(item.date), AppConfig.dateFormat)
       : '',
@@ -100,13 +100,13 @@ export function _getArticlePageCardProps(
   };
 }
 
-export function _getCmsPageCardProps(
+export function getCmsPageCardProps(
   item: PageType,
   getRoutedInternalHref: RCHCConfig['utils']['getRoutedInternalHref'],
   defaultImageUrl: string
 ): CardProps {
   return {
-    ...getArticlePageCardProps(item, defaultImageUrl),
+    ...getArticlePageCardPropsBase(item, defaultImageUrl),
     url: getRoutedInternalHref(
       item?.link ?? item?.uri,
       ModuleItemTypeEnum.Page
@@ -122,11 +122,11 @@ export function _collectGeneralCards(
   return items.reduce((result: CardProps[], item) => {
     if (isArticleType(item)) {
       result.push(
-        _getArticlePageCardProps(item, getRoutedInternalHref, defaultImageUrl)
+        getArticlePageCardProps(item, getRoutedInternalHref, defaultImageUrl)
       );
     } else if (isPageType(item)) {
       result.push(
-        _getCmsPageCardProps(item, getRoutedInternalHref, defaultImageUrl)
+        getCmsPageCardProps(item, getRoutedInternalHref, defaultImageUrl)
       );
     }
     // NOTE: Event type is not a general type
@@ -143,6 +143,7 @@ export function _collectGeneralCards(
 export function getGeneralCollectionCards(
   collection: GeneralCollectionType,
   getRoutedInternalHref: RCHCConfig['utils']['getRoutedInternalHref'],
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   locale = 'fi'
 ): CardProps[] {
   const defaultImageUrl = getEventPlaceholderImage('');

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,7 @@ import { Language } from './types';
 export const ROUTES = {
   SEARCH: '/search',
   COURSES: '/courses/[eventId]',
+  ARTICLEARCHIVE: '/article-archive',
   ARTICLES: '/articles/[...slug]',
   PAGES: '/pages/[...slug]',
   LINK: '',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ import { Language } from './types';
 export const ROUTES = {
   SEARCH: '/search',
   COURSES: '/courses/[eventId]',
-  ARTICLEARCHIVE: '/article-archive',
+  ARTICLE_ARCHIVE: '/article-archive',
   ARTICLES: '/articles/[...slug]',
   PAGES: '/pages/[...slug]',
   LINK: '',

--- a/src/domain/app/AppConfig.ts
+++ b/src/domain/app/AppConfig.ts
@@ -38,6 +38,18 @@ class AppConfig {
     return i18n.locales;
   }
 
+  static get dateFormat() {
+    return 'dd.MM.yyyy';
+  }
+
+  static get shortDatetimeFormat() {
+    return 'dd.MM.yyyy HH:mm';
+  }
+
+  static get datetimeFormat() {
+    return 'dd.MM.yyyy HH:mm:ss';
+  }
+
   static get allowUnauthorizedRequests() {
     return Boolean(
       parseEnvValue(process.env.NEXT_PUBLIC_ALLOW_UNAUTHORIZED_REQUESTS)

--- a/src/domain/nextApi/graphql/generated/graphql.tsx
+++ b/src/domain/nextApi/graphql/generated/graphql.tsx
@@ -425,6 +425,8 @@ export type QueryEventListArgs = {
   allOngoing?: InputMaybe<Scalars['Boolean']>;
   allOngoingAnd?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   allOngoingOr?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  audienceMaxAgeLt?: InputMaybe<Scalars['String']>;
+  audienceMinAgeGt?: InputMaybe<Scalars['String']>;
   combinedText?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   division?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   end?: InputMaybe<Scalars['String']>;

--- a/src/hooks/useRHHCConfig.tsx
+++ b/src/hooks/useRHHCConfig.tsx
@@ -38,7 +38,7 @@ export default function useRHHCConfig(
       LINKEDEVENTS_API_EVENT_ENDPOINT,
     ];
     const getIsHrefExternal = (href: string) => {
-      if (href.startsWith('/')) return false;
+      if (href?.startsWith('/')) return false;
       if (!internalHrefOrigins.some((origin) => href?.includes(origin))) {
         return true;
       }
@@ -76,11 +76,7 @@ export default function useRHHCConfig(
         );
       }
       //TODO: test the default case
-      return getLocalizedCmsItemUrl(
-        link,
-        {},
-        locale
-      );
+      return getLocalizedCmsItemUrl(link, {}, locale);
     };
     return {
       ...rhhcDefaultConfig,

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -40,13 +40,13 @@ export default function ArticleArchive() {
     notifyOnNetworkStatusChange: true,
     variables: {
       first: BLOCK_SIZE,
-      // search: debouncedSearchTerm ?? '',
+      search: debouncedSearchTerm ?? '',
     },
   });
 
   const isLoading = loading && networkStatus !== NetworkStatus.fetchMore;
   const isLoadingMore = networkStatus === NetworkStatus.fetchMore;
-  const pageInfo = articlesData?.posts?.pageInfo ?? {};
+  const pageInfo = articlesData?.posts?.pageInfo;
   const hasMoreToLoad = pageInfo?.hasNextPage ?? false;
 
   const fetchMoreArticles = async () => {
@@ -81,10 +81,16 @@ export default function ArticleArchive() {
           }}
           largeFirstItem
           createLargeCard={(item) => (
-            <LargeCard {...getArticlePageCardProps(item as ArticleType)} />
+            <LargeCard
+              key={`lg-card-${item?.id}`}
+              {...getArticlePageCardProps(item as ArticleType)}
+            />
           )}
           createCard={(item) => (
-            <Card {...getArticlePageCardProps(item as ArticleType)} />
+            <Card
+              key={`sm-card-${item?.id}`}
+              {...getArticlePageCardProps(item as ArticleType)}
+            />
           )}
           hasMore={hasMoreToLoad}
           isLoading={isLoading || isLoadingMore}

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -76,7 +76,7 @@ export default function ArticleArchive() {
 
   return (
     <HCRCApolloPage
-      uri={ROUTES.ARTICLEARCHIVE}
+      uri={ROUTES.ARTICLE_ARCHIVE}
       className="pageLayout"
       navigation={<Navigation />}
       content={

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -6,14 +6,12 @@ import {
 } from 'react-helsinki-headless-cms/apollo';
 import {
   Card,
-  getArticlePageCardProps,
   LargeCard,
   SearchPageContent,
   ArticleType,
   useConfig,
 } from 'react-helsinki-headless-cms';
 import { NetworkStatus } from '@apollo/client';
-import { ModuleItemTypeEnum } from 'react-helsinki-headless-cms';
 
 import getHobbiesStaticProps from '../../domain/app/getHobbiesStaticProps';
 import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTranslationsWithCommon';
@@ -27,7 +25,6 @@ import {
   getEventPlaceholderImage,
   _getArticlePageCardProps,
 } from '../../common-events/utils/headless-cms/headlessCmsUtils';
-import useLocale from '../../common-events/hooks/useLocale';
 
 const BLOCK_SIZE = 10;
 const SEARCH_DEBOUNCE_TIME = 500;
@@ -52,7 +49,6 @@ export default function ArticleArchive() {
       search: debouncedSearchTerm ?? '',
     },
   });
-  const locale = useLocale();
 
   const isLoading = loading && networkStatus !== NetworkStatus.fetchMore;
   const isLoadingMore = networkStatus === NetworkStatus.fetchMore;
@@ -73,7 +69,11 @@ export default function ArticleArchive() {
   };
 
   const articles = articlesData?.posts?.edges?.map((edge) => edge?.node).flat();
+  // The default image when the CMS does not offer any
   const defaultImageUrl = getEventPlaceholderImage('');
+  // Show the first item large when the search has not yet done
+  const showFirstItemLarge = searchTerm.length == 0 ? true : false;
+
   return (
     <HCRCApolloPage
       uri={ROUTES.ARTICLEARCHIVE}
@@ -83,13 +83,14 @@ export default function ArticleArchive() {
         <SearchPageContent
           // customContent={customContent}
           items={articles}
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           onSearch={(freeSearch, tags) => {
             setSearchTerm(freeSearch);
           }}
           onLoadMore={() => {
             fetchMoreArticles();
           }}
-          largeFirstItem={searchTerm.length == 0 ? true : false}
+          largeFirstItem={showFirstItemLarge}
           createLargeCard={(item) => (
             <LargeCard
               key={`lg-card-${item?.id}`}

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -23,7 +23,7 @@ import useDebounce from '../../common/hooks/useDebounce';
 import { useCmsApollo } from '../../domain/clients/cmsApolloClient';
 import {
   getEventPlaceholderImage,
-  _getArticlePageCardProps,
+  getArticlePageCardProps,
 } from '../../common-events/utils/headless-cms/headlessCmsUtils';
 
 const BLOCK_SIZE = 10;
@@ -94,7 +94,7 @@ export default function ArticleArchive() {
           createLargeCard={(item) => (
             <LargeCard
               key={`lg-card-${item?.id}`}
-              {..._getArticlePageCardProps(
+              {...getArticlePageCardProps(
                 item as ArticleType,
                 getRoutedInternalHref,
                 defaultImageUrl
@@ -105,7 +105,7 @@ export default function ArticleArchive() {
             <Card
               key={`sm-card-${item?.id}`}
               {...{
-                ..._getArticlePageCardProps(
+                ...getArticlePageCardProps(
                   item as ArticleType,
                   getRoutedInternalHref,
                   defaultImageUrl

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { GetStaticPropsContext } from 'next';
+import {
+  Page as HCRCApolloPage,
+  usePostsQuery,
+} from 'react-helsinki-headless-cms/apollo';
+import {
+  Card,
+  getArticlePageCardProps,
+  LargeCard,
+  SearchPageContent,
+  ArticleType,
+} from 'react-helsinki-headless-cms';
+import { NetworkStatus } from '@apollo/client';
+
+import getHobbiesStaticProps from '../../domain/app/getHobbiesStaticProps';
+import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTranslationsWithCommon';
+import { ROUTES } from '../../constants';
+import Navigation from '../../common-events/components/navigation/Navigation';
+import FooterSection from '../../domain/footer/Footer';
+import { getLocaleOrError } from '../../utils/routerUtils';
+import useDebounce from '../../common/hooks/useDebounce';
+import { useCmsApollo } from '../../domain/clients/cmsApolloClient';
+
+const BLOCK_SIZE = 10;
+const SEARCH_DEBOUNCE_TIME = 500;
+
+export default function ArticleArchive() {
+  const [searchTerm, setSearchTerm] = React.useState('');
+  const debouncedSearchTerm = useDebounce(searchTerm, SEARCH_DEBOUNCE_TIME);
+  const cmsClient = useCmsApollo({});
+
+  const {
+    data: articlesData,
+    fetchMore,
+    loading,
+    networkStatus,
+  } = usePostsQuery({
+    client: cmsClient,
+    notifyOnNetworkStatusChange: true,
+    variables: {
+      first: BLOCK_SIZE,
+      // search: debouncedSearchTerm ?? '',
+    },
+  });
+
+  const isLoading = loading && networkStatus !== NetworkStatus.fetchMore;
+  const isLoadingMore = networkStatus === NetworkStatus.fetchMore;
+  const pageInfo = articlesData?.posts?.pageInfo ?? {};
+  const hasMoreToLoad = pageInfo?.hasNextPage ?? false;
+
+  const fetchMoreArticles = async () => {
+    if (hasMoreToLoad) {
+      try {
+        await fetchMore({
+          variables: {
+            first: BLOCK_SIZE,
+            after: pageInfo?.endCursor,
+          },
+        });
+      } catch (e) {}
+    }
+  };
+
+  const articles = articlesData?.posts?.edges?.map((edge) => edge?.node).flat();
+
+  return (
+    <HCRCApolloPage
+      uri={ROUTES.ARTICLEARCHIVE}
+      className="pageLayout"
+      navigation={<Navigation />}
+      content={
+        <SearchPageContent
+          // customContent={customContent}
+          items={articles}
+          onSearch={(freeSearch, tags) => {
+            setSearchTerm(freeSearch);
+          }}
+          onLoadMore={() => {
+            fetchMoreArticles();
+          }}
+          largeFirstItem
+          createLargeCard={(item) => (
+            <LargeCard {...getArticlePageCardProps(item as ArticleType)} />
+          )}
+          createCard={(item) => (
+            <Card {...getArticlePageCardProps(item as ArticleType)} />
+          )}
+          hasMore={hasMoreToLoad}
+          isLoading={isLoading || isLoadingMore}
+        />
+      }
+      footer={<FooterSection />}
+    />
+  );
+}
+
+export async function getStaticProps(context: GetStaticPropsContext) {
+  return getHobbiesStaticProps(context, async () => {
+    const locale = getLocaleOrError(context.locale);
+
+    return {
+      props: {
+        ...(await serverSideTranslationsWithCommon(locale, [
+          'common',
+          'home',
+          'cms',
+        ])),
+      },
+    };
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7648,10 +7648,10 @@ react-fast-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-helsinki-headless-cms@1.0.0-alpha2-canary-d7281fe:
-  version "1.0.0-alpha2-canary-d7281fe"
-  resolved "https://registry.yarnpkg.com/react-helsinki-headless-cms/-/react-helsinki-headless-cms-1.0.0-alpha2-canary-d7281fe.tgz#cd0a45174facd0afa55724ca4e7528d8ce52fa3b"
-  integrity sha512-2IneCNzPugHQ2Xwy3hYmZywOuZx+pbdARBf48ysEXximx2yWUn1fN1zfIbSZJmg21JdHcaI+jMawjYEBxSxDxw==
+react-helsinki-headless-cms@1.0.0-alpha2-canary-27b5f0d:
+  version "1.0.0-alpha2-canary-27b5f0d"
+  resolved "https://registry.yarnpkg.com/react-helsinki-headless-cms/-/react-helsinki-headless-cms-1.0.0-alpha2-canary-27b5f0d.tgz#ee2d27a312d48667bdb2380daf50dea1e9dc69b9"
+  integrity sha512-9rel4fHILBksC2tsw0aPd5ZWaJe49vPA28O6K8PRyLISfNJnqJsk96uIGVYV1h2XWJD4MfshEkHBo4jYMrdvog==
   dependencies:
     hds-design-tokens "^1.11.1"
     html-react-parser "^1.4.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7648,10 +7648,10 @@ react-fast-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-helsinki-headless-cms@1.0.0-alpha2-canary-27b5f0d:
-  version "1.0.0-alpha2-canary-27b5f0d"
-  resolved "https://registry.yarnpkg.com/react-helsinki-headless-cms/-/react-helsinki-headless-cms-1.0.0-alpha2-canary-27b5f0d.tgz#ee2d27a312d48667bdb2380daf50dea1e9dc69b9"
-  integrity sha512-9rel4fHILBksC2tsw0aPd5ZWaJe49vPA28O6K8PRyLISfNJnqJsk96uIGVYV1h2XWJD4MfshEkHBo4jYMrdvog==
+react-helsinki-headless-cms@1.0.0-alpha2-canary-0dc40ae:
+  version "1.0.0-alpha2-canary-0dc40ae"
+  resolved "https://registry.yarnpkg.com/react-helsinki-headless-cms/-/react-helsinki-headless-cms-1.0.0-alpha2-canary-0dc40ae.tgz#d0170ebe8b6acb5642a96ed8143566f9366e66ca"
+  integrity sha512-tmYVm53qxe06mAQu9R4Gg9BaPkExqgPWJOSPBiLKR2wLEIBvVHMHgexSa2vCDCLMLKf2TQJMY+y9H3r7XWQJ6Q==
   dependencies:
     hds-design-tokens "^1.11.1"
     html-react-parser "^1.4.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7648,10 +7648,10 @@ react-fast-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-helsinki-headless-cms@1.0.0-alpha2-canary-0dc40ae:
-  version "1.0.0-alpha2-canary-0dc40ae"
-  resolved "https://registry.yarnpkg.com/react-helsinki-headless-cms/-/react-helsinki-headless-cms-1.0.0-alpha2-canary-0dc40ae.tgz#d0170ebe8b6acb5642a96ed8143566f9366e66ca"
-  integrity sha512-tmYVm53qxe06mAQu9R4Gg9BaPkExqgPWJOSPBiLKR2wLEIBvVHMHgexSa2vCDCLMLKf2TQJMY+y9H3r7XWQJ6Q==
+react-helsinki-headless-cms@1.0.0-alpha2-canary-bd861cc:
+  version "1.0.0-alpha2-canary-bd861cc"
+  resolved "https://registry.yarnpkg.com/react-helsinki-headless-cms/-/react-helsinki-headless-cms-1.0.0-alpha2-canary-bd861cc.tgz#a3e5de2658e795e45972968f8f92650adde70e1d"
+  integrity sha512-NgVXKQ9gtVyqSh3IDzHLrKvE3dXxO8wOrokC1aX7ZYbjfg7HfzVTIkjuhNbneByr80Yd+vhvYvXSn5PQOq2D/g==
   dependencies:
     hds-design-tokens "^1.11.1"
     html-react-parser "^1.4.8"


### PR DESCRIPTION
Articles archive CMS page.

![image](https://user-images.githubusercontent.com/389204/185902212-4cf8f604-577f-4d78-a644-6e9702111d6c.png)

Depends on https://github.com/City-of-Helsinki/react-helsinki-headless-cms/pull/37, but the change is already published in the new HCRC-package.

The route: `/articles` which is also localized to `/artikkelit` (e.g. https://harrastus-helsinki-39.test.kuva.hel.ninja/fi/artikkelit)