### PR TITLE
feat(archive): fetch the categories and filter articles with them

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-content-loader": "^6.2.0",
     "react-datepicker": "^4.8.0",
     "react-dom": "18.1.0",
-    "react-helsinki-headless-cms": "1.0.0-alpha2-canary-302d3b5",
+    "react-helsinki-headless-cms": "1.0.0-alpha5-canary-736bf23",
     "react-scroll": "^1.8.7",
     "react-toastify": "^9.0.3",
     "sanitize-html": "^2.7.0",

--- a/src/domain/event/eventCard/EventCard.tsx
+++ b/src/domain/event/eventCard/EventCard.tsx
@@ -73,7 +73,7 @@ const EventCard: React.FC<Props> = ({ event }) => {
 
   return (
     <LinkBox
-      ariaLabel={t('event:eventCard.ariaLabelLink', {
+      aria-label={t('event:eventCard.ariaLabelLink', {
         name,
       })}
       id={getEventCardId(id)}

--- a/src/domain/event/eventCard/LargeEventCard.tsx
+++ b/src/domain/event/eventCard/LargeEventCard.tsx
@@ -98,7 +98,7 @@ const LargeEventCard: React.FC<Props> = ({ event }) => {
   return (
     <LinkBox
       type="linkBox"
-      ariaLabel={t('event:eventCard.ariaLabelLink', {
+      aria-label={t('event:eventCard.ariaLabelLink', {
         name,
       })}
       id={getLargeEventCardId(id)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7648,10 +7648,10 @@ react-fast-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-helsinki-headless-cms@1.0.0-alpha2-canary-302d3b5:
-  version "1.0.0-alpha2-canary-302d3b5"
-  resolved "https://registry.yarnpkg.com/react-helsinki-headless-cms/-/react-helsinki-headless-cms-1.0.0-alpha2-canary-302d3b5.tgz#6364d9f1de6bf9cb98357ef63148d35c7ba81e6c"
-  integrity sha512-aDx3EbZsUDICdOpbEY3EMAhz3nKgn5SrTlPovk0tgrKELS9IotAK8scbyrMA0+IXHy2jxHJT6Ss8i2PPRGpB3A==
+react-helsinki-headless-cms@1.0.0-alpha5-canary-736bf23:
+  version "1.0.0-alpha5-canary-736bf23"
+  resolved "https://registry.yarnpkg.com/react-helsinki-headless-cms/-/react-helsinki-headless-cms-1.0.0-alpha5-canary-736bf23.tgz#f83043c8c5e785bf2b078d3bd48fc57993f1cc4e"
+  integrity sha512-VyGPOANnfKGFD9HvNR1oVMGoawyZ4IWeJeMKE9VHhB5rN5tFBmCOKKP0FejBE9qUU8yDYauItAheZG0zkr6HuQ==
   dependencies:
     hds-design-tokens "^1.11.1"
     html-react-parser "^1.4.8"


### PR DESCRIPTION
HH-155 HH-156

The route inside the app:` /fi/artikkelit`

NOTE: Needs the changes from https://github.com/City-of-Helsinki/react-helsinki-headless-cms/pull/40.

English categories:
<img width="1125" alt="image" src="https://user-images.githubusercontent.com/389204/186689282-602ed9f7-56dd-4270-b062-08e3faed9d96.png">

Finnish categories:
<img width="1124" alt="image" src="https://user-images.githubusercontent.com/389204/186689381-19a09b40-59e3-4d53-b937-03a7f88efd6d.png">

Filtered with Uutiset:
<img width="1117" alt="image" src="https://user-images.githubusercontent.com/389204/186689450-d4818f2c-e4ef-497a-845a-dbeb88e58abc.png">
