### PR TITLE
Localised routing improvements

### DIFF
--- a/src/common-events/components/navigation/Navigation.tsx
+++ b/src/common-events/components/navigation/Navigation.tsx
@@ -1,3 +1,4 @@
+import { ArticleType, PageType } from 'react-helsinki-headless-cms';
 import { Navigation as RHHCApolloNavigation } from 'react-helsinki-headless-cms/apollo';
 
 import { DEFAULT_HEADER_MENU_NAME } from '../../../constants';
@@ -8,12 +9,18 @@ import {
 } from '../../../utils/routerUtils';
 import useLocale from '../../hooks/useLocale';
 import useRouterFromConfig from '../../hooks/useRouterFromConfig';
+import { getSlugFromUri } from '../../utils/headless-cms/headlessCmsUtils';
 
-export default function Navigation() {
+type NavigationProps = {
+  page?: PageType | ArticleType;
+};
+
+export default function Navigation({ page }: NavigationProps) {
   const router = useRouterFromConfig();
   const locale = useLocale();
   const navigationMenuName = DEFAULT_HEADER_MENU_NAME[locale];
   const currentPage = router.pathname;
+
   return (
     <RHHCApolloNavigation
       menuName={navigationMenuName ?? ''}
@@ -22,9 +29,17 @@ export default function Navigation() {
       }}
       getIsItemActive={({ path }) => path === getI18nPath(currentPage, locale)}
       getPathnameForLanguage={({ slug }) => {
+        const translatedPage = page?.translations?.find(
+          (translation: PageType['translations'][number]) =>
+            translation.language.slug === slug
+        );
         return getLocalizedCmsItemUrl(
           currentPage,
-          router.query,
+          translatedPage
+            ? {
+                slug: getSlugFromUri(translatedPage.uri) ?? '',
+              }
+            : router.query,
           slug as Language
         );
       }}

--- a/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
+++ b/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
@@ -1,10 +1,5 @@
 import format from 'date-fns/format';
 import {
-  Categories,
-  Category,
-  CollectionItemType,
-} from 'react-helsinki-headless-cms';
-import {
   ArticleType,
   Card,
   Category,

--- a/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
+++ b/src/common-events/utils/headless-cms/headlessCmsUtils.tsx
@@ -1,5 +1,10 @@
 import format from 'date-fns/format';
 import {
+  Categories,
+  Category,
+  CollectionItemType,
+} from 'react-helsinki-headless-cms';
+import {
   ArticleType,
   Card,
   Category,

--- a/src/common-events/utils/headless-cms/service.tsx
+++ b/src/common-events/utils/headless-cms/service.tsx
@@ -1,0 +1,222 @@
+import { ArticleType, PageType } from 'react-helsinki-headless-cms';
+import {
+  // MenuQuery,
+  // MenuQueryVariables,
+  // MenuDocument,
+  // PageQuery,
+  // PageQueryVariables,
+  // PageDocument,
+  PostsQuery,
+  PostsQueryVariables,
+  PostsDocument,
+  PagesQuery,
+  PagesQueryVariables,
+  PagesDocument,
+} from 'react-helsinki-headless-cms/apollo';
+
+// import {
+//   DEFAULT_HEADER_MENU_NAME,
+//   SUPPORT_LANGUAGES,
+// } from '../../../constants';
+import { createCmsApolloClient } from '../../../domain/clients/cmsApolloClient';
+import { PageInfo } from './types';
+
+export const ARTICLES_AMOUNT_LIMIT = 100;
+export const PAGES_AMOUNT_LIMIT = 100;
+
+export const getAllArticles = async (): Promise<PageInfo[]> => {
+  const pageInfos: PageInfo[] = [];
+  const cmsClient = createCmsApolloClient();
+  const { data: articlesData } = await cmsClient.query<
+    PostsQuery,
+    PostsQueryVariables
+  >({
+    query: PostsDocument,
+    variables: {
+      first: ARTICLES_AMOUNT_LIMIT,
+    },
+  });
+  articlesData.posts?.edges?.forEach((edge) =>
+    addArticleToPageInfosArray(edge?.node as ArticleType)
+  );
+  return pageInfos;
+
+  function addArticleToPageInfosArray(node: ArticleType) {
+    if (node && node.uri && node.slug && node.language?.code) {
+      pageInfos.push({
+        uri: node.uri,
+        locale: node.language.code.toLowerCase(),
+        slug: node.slug,
+      });
+      node.translations?.forEach((translation: PageType['translations']) => {
+        if (
+          translation?.uri &&
+          translation.slug &&
+          translation.language?.code
+        ) {
+          const {
+            uri,
+            slug,
+            language: { code },
+          } = translation;
+          pageInfos.push({
+            uri,
+            slug,
+            locale: code.toLocaleLowerCase(),
+          });
+        }
+      });
+    }
+  }
+};
+
+export const getAllPages = async (): Promise<PageInfo[]> => {
+  const pageInfos: PageInfo[] = [];
+  const cmsClient = createCmsApolloClient();
+  const { data: pagesData } = await cmsClient.query<
+    PagesQuery,
+    PagesQueryVariables
+  >({
+    query: PagesDocument,
+    variables: {
+      first: PAGES_AMOUNT_LIMIT,
+    },
+  });
+  pagesData.pages?.edges?.forEach((edge) =>
+    addPagesToPageInfosArray(edge?.node as PageType)
+  );
+  return pageInfos;
+
+  function addPagesToPageInfosArray(node: PageType) {
+    if (node && node.uri && node.slug && node.language?.code) {
+      pageInfos.push({
+        uri: node.uri,
+        locale: node.language.code.toLowerCase(),
+        slug: node.slug,
+      });
+      node.translations?.forEach((translation: PageType['translations']) => {
+        if (
+          translation?.uri &&
+          translation.slug &&
+          translation.language?.code
+        ) {
+          const {
+            uri,
+            slug,
+            language: { code },
+          } = translation;
+          pageInfos.push({
+            uri,
+            slug,
+            locale: code.toLocaleLowerCase(),
+          });
+        }
+      });
+    }
+  }
+};
+
+// function addNodesToPageInfosArray(
+//   node: PageType | ArticleType,
+//   pageInfos: PageInfo[]
+// ) {
+//   if (node && node.uri && node.slug && node.language?.code) {
+//     pageInfos.push({
+//       uri: node.uri,
+//       locale: node.language.code.toLowerCase(),
+//       slug: node.slug,
+//     });
+//     node.translations?.forEach((translation) => {
+//       if (translation?.uri && translation.slug && translation.language?.code) {
+//         const {
+//           uri,
+//           slug,
+//           language: { code },
+//         } = translation;
+//         pageInfos.push({
+//           uri,
+//           slug,
+//           locale: code.toLocaleLowerCase(),
+//         });
+//       }
+//     });
+//   }
+// }
+
+/*
+export const getAllMenuPages = async (
+  locale: SUPPORT_LANGUAGES
+): Promise<PageInfo[]> => {
+  const pageInfos: PageInfo[] = [];
+  const cmsClient = createCmsApolloClient();
+  const { data: navigationData } = await cmsClient.query<
+    MenuQuery,
+    MenuQueryVariables
+  >({
+    query: MenuDocument,
+    variables: {
+      id: DEFAULT_HEADER_MENU_NAME[locale ?? 'fi'],
+    },
+  });
+
+  const menuItemPromises = navigationData.menu?.menuItems?.nodes?.map(
+    (menuItem) => getPageChildren(menuItem?.connectedNode?.node as PageType)
+  );
+
+  if (menuItemPromises) {
+    await Promise.all(menuItemPromises);
+  }
+
+  return pageInfos;
+
+  async function getPageChildren(node?: PageType): Promise<unknown> {
+    if (node) addPageToPageInfosArray(node);
+    if (node?.children?.nodes) {
+      return Promise.all(
+        node.children.nodes.map(async (page: PageType) => {
+          if (page?.id) {
+            const { data: childPage } = await cmsClient.query<
+              PageQuery,
+              PageQueryVariables
+            >({
+              query: PageDocument,
+              variables: {
+                id: page.id,
+              },
+            });
+            return getPageChildren(childPage.page as PageType);
+          }
+        })
+      );
+    }
+  }
+
+  function addPageToPageInfosArray(node: PageType) {
+    if (node && node.uri && node.slug && node.language?.code) {
+      pageInfos.push({
+        uri: node.uri,
+        locale: node.language.code.toLowerCase(),
+        slug: node.slug,
+      });
+      node.translations?.forEach((translation: PageType['translation']) => {
+        if (
+          translation?.uri &&
+          translation.slug &&
+          translation.language?.code
+        ) {
+          const {
+            uri,
+            slug,
+            language: { code },
+          } = translation;
+          pageInfos.push({
+            uri,
+            slug,
+            locale: code.toLocaleLowerCase(),
+          });
+        }
+      });
+    }
+  }
+};
+*/

--- a/src/common-events/utils/headless-cms/types.ts
+++ b/src/common-events/utils/headless-cms/types.ts
@@ -1,0 +1,1 @@
+export type PageInfo = { uri: string; slug: string; locale: string };

--- a/src/domain/app/getHobbiesStaticProps.ts
+++ b/src/domain/app/getHobbiesStaticProps.ts
@@ -50,6 +50,11 @@ type HobbiesContext = {
   eventsClient: ApolloClient<NormalizedCacheObject>;
 };
 
+export type HobbiesGlobalPageProps = {
+  initialApolloState: NormalizedCacheObject;
+  initialEventsApolloState: NormalizedCacheObject;
+} & unknown; //FIXME: Promise<GetStaticPropsResult<P>> of getHobbiesStaticProps
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function getHobbiesStaticProps<P = Record<string, any>>(
   context: GetStaticPropsContext,

--- a/src/pages/articles/[...slug].tsx
+++ b/src/pages/articles/[...slug].tsx
@@ -10,6 +10,7 @@ import {
   PageContent as RHHCPageContent,
   Page as RHHCPage,
   useConfig,
+  ArticleType,
 } from 'react-helsinki-headless-cms';
 import {
   ArticleDocument,
@@ -34,7 +35,7 @@ import { getLocaleOrError } from '../../utils/routerUtils';
 import { getAllArticles } from '../../common-events/utils/headless-cms/service';
 
 const NextCmsArticle: NextPage<{
-  article: ArticleQuery['post'];
+  article: ArticleType;
   breadcrumbs: Breadcrumb[] | null;
   collections: CollectionType[];
 }> = ({ article, breadcrumbs, collections }) => {
@@ -47,7 +48,7 @@ const NextCmsArticle: NextPage<{
 
   return (
     <RHHCPage
-      navigation={<Navigation />}
+      navigation={<Navigation page={article} />}
       content={
         <RHHCPageContent
           page={article as PageContentProps['page']}

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -15,7 +15,9 @@ import {
 } from 'react-helsinki-headless-cms';
 import { NetworkStatus } from '@apollo/client';
 
-import getHobbiesStaticProps from '../../domain/app/getHobbiesStaticProps';
+import getHobbiesStaticProps, {
+  HobbiesGlobalPageProps,
+} from '../../domain/app/getHobbiesStaticProps';
 import serverSideTranslationsWithCommon from '../../domain/i18n/serverSideTranslationsWithCommon';
 import { ROUTES } from '../../constants';
 import Navigation from '../../common-events/components/navigation/Navigation';
@@ -30,11 +32,13 @@ const CATEGORIES_AMOUNT = 20;
 const BLOCK_SIZE = 10;
 const SEARCH_DEBOUNCE_TIME = 500;
 
-export default function ArticleArchive() {
+export default function ArticleArchive({
+  initialApolloState,
+}: HobbiesGlobalPageProps) {
   const [searchTerm, setSearchTerm] = React.useState('');
   const [searchCategories, setSearchCategories] = React.useState<string[]>([]);
   const debouncedSearchTerm = useDebounce(searchTerm, SEARCH_DEBOUNCE_TIME);
-  const cmsClient = useCmsApollo({});
+  const cmsClient = useCmsApollo(initialApolloState);
   const {
     currentLanguageCode,
     utils: { getRoutedInternalHref },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -44,7 +44,6 @@ const HomePage: NextPage<{
       navigation={<Navigation />}
       content={
         <HCRCPageContent
-          breadcrumbs={[]}
           page={page}
           landingPage={landingPage}
           PageContentLayoutComponent={LandingPageContentLayout}

--- a/src/pages/pages/[...slug].tsx
+++ b/src/pages/pages/[...slug].tsx
@@ -10,6 +10,7 @@ import {
   Page as HCRCPage,
   PageContentProps,
   useConfig,
+  PageType,
 } from 'react-helsinki-headless-cms';
 import {
   PageDocument,
@@ -31,7 +32,7 @@ import { Language } from '../../types';
 import { getLocaleOrError } from '../../utils/routerUtils';
 
 const NextCmsPage: NextPage<{
-  page: PageQuery['page'];
+  page: PageType;
   breadcrumbs: Breadcrumb[] | null;
   collections: CollectionType[];
 }> = ({ page, breadcrumbs, collections }) => {
@@ -42,7 +43,7 @@ const NextCmsPage: NextPage<{
 
   return (
     <HCRCPage
-      navigation={<Navigation />}
+      navigation={<Navigation page={page} />}
       content={
         <HCRCPageContent
           page={page as PageContentProps['page']}


### PR DESCRIPTION
1. Load the static paths with getStaticPath SSR-function.
2. Change to a translated CMS page (or article) on language change if one is available.

HH-120 HH-122

Relates to #49 which drives for routing with the middleware instead of configurable utility function