### PR TITLE
feat: show only 2 tags per card with rest count

### DIFF
--- a/src/common-events/components/keyword/Keyword.tsx
+++ b/src/common-events/components/keyword/Keyword.tsx
@@ -8,7 +8,7 @@ interface Props {
   color?: 'engelLight50' | 'tramLight20' | 'black10';
   hideOnMobile?: boolean;
   keyword: string;
-  onClick: () => void;
+  onClick?: () => void;
 }
 
 const Keyword: FunctionComponent<Props> = ({
@@ -20,7 +20,7 @@ const Keyword: FunctionComponent<Props> = ({
 }) => {
   const handleClick = (ev: React.MouseEvent) => {
     ev.preventDefault();
-    onClick();
+    onClick && onClick();
   };
 
   return (

--- a/src/domain/article/articleDetails/ArticleDetails.tsx
+++ b/src/domain/article/articleDetails/ArticleDetails.tsx
@@ -15,11 +15,13 @@ const ArticleDetails: React.FC<ArticleDetailsProps> = ({ keywords }) => {
 
   return (
     <div className={styles.tags}>
-      {[first, second].map((tag) => (
-        <Tag variant="card" key={tag}>
-          {tag}
-        </Tag>
-      ))}
+      {[first, second]
+        .filter((t) => t)
+        .map((tag) => (
+          <Tag variant="card" key={tag}>
+            {tag}
+          </Tag>
+        ))}
       {!!restKeywords.length && (
         <Tag variant="card">{`+${restKeywords.length}`}</Tag>
       )}

--- a/src/domain/article/articleDetails/ArticleDetails.tsx
+++ b/src/domain/article/articleDetails/ArticleDetails.tsx
@@ -11,13 +11,23 @@ const ArticleDetails: React.FC<ArticleDetailsProps> = ({ keywords }) => {
     return null;
   }
 
+  const [first, second, ...restKeywords] = keywords;
+
   return (
     <div className={styles.tags}>
-      {keywords.map((keyword) => (
-        <Tag variant="card" key={keyword}>
-          {keyword}
+      {first && (
+        <Tag variant="card" key={first}>
+          {first}
         </Tag>
-      ))}
+      )}
+      {second && (
+        <Tag variant="card" key={second}>
+          {second}
+        </Tag>
+      )}
+      {!!restKeywords.length && (
+        <Tag variant="card">{`+${restKeywords.length}`}</Tag>
+      )}
     </div>
   );
 };

--- a/src/domain/article/articleDetails/ArticleDetails.tsx
+++ b/src/domain/article/articleDetails/ArticleDetails.tsx
@@ -15,16 +15,11 @@ const ArticleDetails: React.FC<ArticleDetailsProps> = ({ keywords }) => {
 
   return (
     <div className={styles.tags}>
-      {first && (
-        <Tag variant="card" key={first}>
-          {first}
+      {[first, second].map((tag) => (
+        <Tag variant="card" key={tag}>
+          {tag}
         </Tag>
-      )}
-      {second && (
-        <Tag variant="card" key={second}>
-          {second}
-        </Tag>
-      )}
+      ))}
       {!!restKeywords.length && (
         <Tag variant="card">{`+${restKeywords.length}`}</Tag>
       )}

--- a/src/domain/event/__tests__/EventPageContainer.test.tsx
+++ b/src/domain/event/__tests__/EventPageContainer.test.tsx
@@ -143,7 +143,7 @@ it('should render info and load other events + similar events', async () => {
   expect(screen.queryByRole('heading', { name: 'Kuvaus' })).toBeInTheDocument();
   expect(screen.queryByText(description)).toBeInTheDocument();
 
-  keywords.forEach((keyword) => {
+  keywords.slice(0, 2).forEach((keyword) => {
     expect(
       screen.queryByRole('link', { name: keyword.name })
     ).toBeInTheDocument();

--- a/src/domain/event/eventDetails/EventDetails.tsx
+++ b/src/domain/event/eventDetails/EventDetails.tsx
@@ -49,7 +49,7 @@ const EventDetails: React.FC<EventDetailsProps> = (props) => {
         </div>
       )}
       <div className={styles.infoRow}>
-        <EventKeywords event={event} showIsFree />
+        <EventKeywords event={event} showIsFree showKeywordsCount />
       </div>
     </div>
   );

--- a/src/domain/event/eventKeywords/EventKeywords.tsx
+++ b/src/domain/event/eventKeywords/EventKeywords.tsx
@@ -63,6 +63,12 @@ const EventKeywords: React.FC<Props> = ({
   const [first, second, ...restKeywords] = keywords;
   const customTagsCount = Number(thisWeek) + Number(showIsFree && freeEvent);
 
+  /**
+   * 2 custom tags: isFree and today || thisWeek: so customTags count is from 0-2
+   * Depending on the value, we shoud either show either hide first and second keywords and adjust the
+   * count tag value accordingly
+   */
+
   return (
     <>
       {today && (

--- a/src/domain/event/eventKeywords/EventKeywords.tsx
+++ b/src/domain/event/eventKeywords/EventKeywords.tsx
@@ -93,29 +93,19 @@ const EventKeywords: React.FC<Props> = ({
         />
       )}
       {showKeywords &&
-        first &&
-        (showKeywordsCount ? customTagsCount < 2 : true) && (
-          <Keyword
-            color="engelLight50"
-            blackOnMobile={blackOnMobile}
-            hideOnMobile={hideKeywordsOnMobile}
-            key={first.id}
-            keyword={first.name}
-            onClick={handleClick('text', first.name)}
-          />
-        )}
-      {showKeywords &&
-        second &&
-        (showKeywordsCount ? customTagsCount < 2 : true) && (
-          <Keyword
-            color="engelLight50"
-            blackOnMobile={blackOnMobile}
-            hideOnMobile={hideKeywordsOnMobile}
-            key={second.id}
-            keyword={second.name}
-            onClick={handleClick('text', second.name)}
-          />
-        )}
+        (showKeywordsCount ? customTagsCount < 2 : true) &&
+        [first, second]
+          .filter((t) => t)
+          .map((tag) => (
+            <Keyword
+              color="engelLight50"
+              blackOnMobile={blackOnMobile}
+              hideOnMobile={hideKeywordsOnMobile}
+              key={tag.id}
+              keyword={tag.name}
+              onClick={handleClick('text', tag.name)}
+            />
+          ))}
       {!!restKeywords.length && showKeywords && showKeywordsCount && (
         <Keyword
           color="engelLight50"

--- a/src/domain/event/eventKeywords/EventKeywords.tsx
+++ b/src/domain/event/eventKeywords/EventKeywords.tsx
@@ -93,19 +93,31 @@ const EventKeywords: React.FC<Props> = ({
         />
       )}
       {showKeywords &&
-        (showKeywordsCount ? customTagsCount < 2 : true) &&
-        [first, second]
-          .filter((t) => t)
-          .map((tag) => (
-            <Keyword
-              color="engelLight50"
-              blackOnMobile={blackOnMobile}
-              hideOnMobile={hideKeywordsOnMobile}
-              key={tag.id}
-              keyword={tag.name}
-              onClick={handleClick('text', tag.name)}
-            />
-          ))}
+        first &&
+        (showKeywordsCount ? customTagsCount < 2 : true) && (
+          <Keyword
+            color="engelLight50"
+            blackOnMobile={blackOnMobile}
+            hideOnMobile={hideKeywordsOnMobile}
+            key={first.id}
+            keyword={first.name}
+            onClick={handleClick('text', first.name)}
+          />
+        )}
+      {showKeywords &&
+        second &&
+        (showKeywordsCount
+          ? customTagsCount + Number(Boolean(first)) < 2
+          : true) && (
+          <Keyword
+            color="engelLight50"
+            blackOnMobile={blackOnMobile}
+            hideOnMobile={hideKeywordsOnMobile}
+            key={second.id}
+            keyword={second.name}
+            onClick={handleClick('text', second.name)}
+          />
+        )}
       {!!restKeywords.length && showKeywords && showKeywordsCount && (
         <Keyword
           color="engelLight50"

--- a/src/domain/event/eventKeywords/EventKeywords.tsx
+++ b/src/domain/event/eventKeywords/EventKeywords.tsx
@@ -65,7 +65,7 @@ const EventKeywords: React.FC<Props> = ({
 
   /**
    * 2 custom tags: isFree and today || thisWeek: so customTags count is from 0-2
-   * Depending on the value, we shoud either show either hide first and second keywords and adjust the
+   * Depending on the value, we should either show either hide first and second keywords and adjust the
    * count tag value accordingly
    */
 

--- a/src/domain/event/eventKeywords/EventKeywords.tsx
+++ b/src/domain/event/eventKeywords/EventKeywords.tsx
@@ -18,6 +18,7 @@ interface Props {
   hideKeywordsOnMobile?: boolean;
   showIsFree: boolean;
   showKeywords?: boolean;
+  showKeywordsCount?: boolean;
 }
 const EventKeywords: React.FC<Props> = ({
   blackOnMobile,
@@ -25,6 +26,7 @@ const EventKeywords: React.FC<Props> = ({
   hideKeywordsOnMobile = false,
   showIsFree,
   showKeywords = true,
+  showKeywordsCount,
 }) => {
   const { t } = useTranslation();
   const locale = useLocale();
@@ -84,33 +86,36 @@ const EventKeywords: React.FC<Props> = ({
           onClick={handleClick('isFree')}
         />
       )}
-      {showKeywords && first && customTagsCount < 2 && (
-        <Keyword
-          color="engelLight50"
-          blackOnMobile={blackOnMobile}
-          hideOnMobile={hideKeywordsOnMobile}
-          key={first.id}
-          keyword={first.name}
-          onClick={handleClick('text', first.name)}
-        />
-      )}
-      {showKeywords && second && customTagsCount === 0 && (
-        <Keyword
-          color="engelLight50"
-          blackOnMobile={blackOnMobile}
-          hideOnMobile={hideKeywordsOnMobile}
-          key={second.id}
-          keyword={second.name}
-          onClick={handleClick('text', second.name)}
-        />
-      )}
-      {!!restKeywords.length && showKeywords && (
+      {showKeywords &&
+        first &&
+        (showKeywordsCount ? customTagsCount < 2 : true) && (
+          <Keyword
+            color="engelLight50"
+            blackOnMobile={blackOnMobile}
+            hideOnMobile={hideKeywordsOnMobile}
+            key={first.id}
+            keyword={first.name}
+            onClick={handleClick('text', first.name)}
+          />
+        )}
+      {showKeywords &&
+        second &&
+        (showKeywordsCount ? customTagsCount < 2 : true) && (
+          <Keyword
+            color="engelLight50"
+            blackOnMobile={blackOnMobile}
+            hideOnMobile={hideKeywordsOnMobile}
+            key={second.id}
+            keyword={second.name}
+            onClick={handleClick('text', second.name)}
+          />
+        )}
+      {!!restKeywords.length && showKeywords && showKeywordsCount && (
         <Keyword
           color="engelLight50"
           blackOnMobile={blackOnMobile}
           hideOnMobile={hideKeywordsOnMobile}
           keyword={`+${restKeywords.length + customTagsCount}`}
-          onClick={() => null}
         />
       )}
     </>

--- a/src/domain/event/eventKeywords/EventKeywords.tsx
+++ b/src/domain/event/eventKeywords/EventKeywords.tsx
@@ -58,6 +58,9 @@ const EventKeywords: React.FC<Props> = ({
     return null;
   }
 
+  const [first, second, ...restKeywords] = keywords;
+  const customTagsCount = Number(thisWeek) + Number(showIsFree && freeEvent);
+
   return (
     <>
       {today && (
@@ -81,20 +84,35 @@ const EventKeywords: React.FC<Props> = ({
           onClick={handleClick('isFree')}
         />
       )}
-      {!!keywords.length &&
-        showKeywords &&
-        keywords.map((keyword) => {
-          return (
-            <Keyword
-              color="engelLight50"
-              blackOnMobile={blackOnMobile}
-              hideOnMobile={hideKeywordsOnMobile}
-              key={keyword.id}
-              keyword={keyword.name}
-              onClick={handleClick('text', keyword.name)}
-            />
-          );
-        })}
+      {showKeywords && first && customTagsCount < 2 && (
+        <Keyword
+          color="engelLight50"
+          blackOnMobile={blackOnMobile}
+          hideOnMobile={hideKeywordsOnMobile}
+          key={first.id}
+          keyword={first.name}
+          onClick={handleClick('text', first.name)}
+        />
+      )}
+      {showKeywords && second && customTagsCount === 0 && (
+        <Keyword
+          color="engelLight50"
+          blackOnMobile={blackOnMobile}
+          hideOnMobile={hideKeywordsOnMobile}
+          key={second.id}
+          keyword={second.name}
+          onClick={handleClick('text', second.name)}
+        />
+      )}
+      {!!restKeywords.length && showKeywords && (
+        <Keyword
+          color="engelLight50"
+          blackOnMobile={blackOnMobile}
+          hideOnMobile={hideKeywordsOnMobile}
+          keyword={`+${restKeywords.length + customTagsCount}`}
+          onClick={() => null}
+        />
+      )}
     </>
   );
 };


### PR DESCRIPTION
## Description
-for articles its showing first 2 tags and count if needed
-for events there are 3 mandatory tags, 2 of them might be shown same time, and should be shown if they are available: isFree, today or this week. so if those 2 are presented - keywords are not shown at all, and count is shown if needed. If its not free, not today, and not this week then first 2 tags from keywords are shown if they exists, and count if needed.

The tags count is optional, so its showing 2 tags + count only in carousels, in search results and single course view should show all tags

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots
<img width="1415" alt="image" src="https://user-images.githubusercontent.com/16116141/194277028-4c11e737-efa6-43f8-a13e-999c1b86225b.png">


## Additional notes
